### PR TITLE
Inline procedure framework

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,10 +78,10 @@
   <p>The source code for phosphorus is available <a href=https://github.com/nathan/phosphorus>on GitHub</a>.</p>
 </section>
 <script src=fonts.js></script>
-<script src=//cdnjs.cloudflare.com/ajax/libs/jszip/2.4.0/jszip.js></script>
-<script src=//canvg.googlecode.com/svn/trunk/rgbcolor.js></script>
-<script src=//canvg.googlecode.com/svn/trunk/StackBlur.js></script>
-<script src=//canvg.googlecode.com/svn/trunk/canvg.js></script>
+<script src=http://cdnjs.cloudflare.com/ajax/libs/jszip/2.4.0/jszip.js></script>
+<script src=http://canvg.googlecode.com/svn/trunk/rgbcolor.js></script>
+<script src=http://canvg.googlecode.com/svn/trunk/StackBlur.js></script>
+<script src=http://canvg.googlecode.com/svn/trunk/canvg.js></script>
 <script src=phosphorus.js></script>
 <script src=player.js></script>
 <script>


### PR DESCRIPTION
Project example is 45115874
This implements a native substr block with a failsafe for Scratch / non-nativized Phosphorus, but it runs much faster with the flag set.

If this is accepted, I can do more primitives for operations like bitwise for example.