### PR TITLE
Implemented pen alpha and fixed pen dotting.

### DIFF
--- a/phosphorus.js
+++ b/phosphorus.js
@@ -1385,6 +1385,7 @@ var P = (function() {
       context.beginPath();
       context.moveTo(240 + ox, 180 - oy);
       context.lineTo(240 + x, 180 - y);
+      context.closePath();
       context.stroke();
     }
     if (this.saying) {
@@ -1396,16 +1397,12 @@ var P = (function() {
     var context = this.stage.penContext;
     var x = this.scratchX;
     var y = this.scratchY;
-    if (this.penSize % 2 > .5 && this.penSize % 2 < 1.5) {
-      x -= .5;
-      y -= .5;
-    }
-    context.strokeStyle = this.penCSS || 'hsl(' + this.penHue + ',' + this.penSaturation + '%,' + (this.penLightness > 100 ? 200 - this.penLightness : this.penLightness) + '%)';
-    context.lineWidth = this.penSize;
     context.beginPath();
-    context.moveTo(240 + x, 180 - y);
-    context.lineTo(240.01 + x, 180 - y);
-    context.stroke();
+    context.lineWidth = 0;
+    context.fillStyle = this.penCSS || 'hsl(' + this.penHue + ',' + this.penSaturation + '%,' + (this.penLightness > 100 ? 200 - this.penLightness : this.penLightness) + '%)';
+    context.arc(240 + x, 180 - y, this.penSize / 2, 0, 2 * Math.PI, false);
+    context.closePath();
+    context.fill();
   };
 
   Sprite.prototype.draw = function(context, noEffects) {
@@ -2784,8 +2781,11 @@ P.compile = (function() {
 
       } else if (block[0] === 'penColor:') {
 
-        source += 'var c = S.penColor = ' + num(block[1]) + ' & 0xffffff;\n'
-        source += 'S.penCSS = "rgb(" + (c >> 16) + "," + (c >> 8 & 0xff) + "," + (c & 0xff) + ")";\n'
+        source += 'var c = ' + num(block[1]) + ' & 0xffffffff;\n'
+        source += 'S.penColor = c & 0xffffff;\n'
+        source += 'var ca = (0xFF & (c >> 24)) / 255;\n'
+        source += 'if (ca === 0) ca = 1;\n'
+        source += 'S.penCSS = "rgba(" + (c >> 16 & 0xff) + "," + (c >> 8 & 0xff) + "," + (c & 0xff) + ", "+ca+")";\n'
 
       } else if (block[0] === 'setPenHueTo:') {
 


### PR DESCRIPTION
This works almost like the Flash version. The logic is the same but for some reason the blending in the HTML5 canvas is not working like the blending in the Flash Graphics class. The result is that pen stroke opacity seems to 'add up' faster. I tried a few things to work around this but couldn't find anything useful. Perhaps someone else knows?
Flash version (https://scratch.mit.edu/projects/63463578/):
![image](https://cloud.githubusercontent.com/assets/874656/7754169/a0ac3194-ffa7-11e4-8cef-040b40205cbb.png)

This version:
![image](https://cloud.githubusercontent.com/assets/874656/7754176/b5c1dae8-ffa7-11e4-936c-1d08cd1d9366.png)

BTW, I saw another PR for pen alpha that wouldn't behave like the Flash version since it was applying alpha even after changes to pen brightness and hue (which the official version doesn't support).

Also included is a change that makes the pen dot a circle just as it is in now the Flash version.