### PR TITLE
Fix a logic error in warping

### DIFF
--- a/phosphorus.js
+++ b/phosphorus.js
@@ -3628,7 +3628,7 @@ P.runtime = (function() {
 
   var endCall = function() {
     if (CALLS.length) {
-      if (C.warp) WARP--;
+      if (WARP) WARP--;
       IMMEDIATE = C.fn;
       C = CALLS.pop();
       STACK = C.stack;


### PR DESCRIPTION
This caused hangs when atomic procedures called non-atomic procedures. Closes https://github.com/nathan/phosphorus/issues/399.