### PR TITLE
Truncate queue on stopAll instead of assigning a new array

### DIFF
--- a/phosphorus.js
+++ b/phosphorus.js
@@ -3758,7 +3758,7 @@ P.runtime = (function() {
       this.hidePrompt = false;
       this.prompter.style.display = 'none';
       this.promptId = this.nextPromptId = 0;
-      this.queue = [];
+      this.queue.length = 0;
       this.resetFilters();
       this.stopSounds();
       for (var i = 0; i < this.children.length; i++) {


### PR DESCRIPTION
This was breaking stop all because Stage::step caches this.queue for performance reasons.

Fixes https://github.com/nathan/phosphorus/issues/507 and https://github.com/nathan/phosphorus/issues/508.