### PR TITLE
Add loadSB2Object for loading `zip` object directly from tosh

### DIFF
--- a/phosphorus.js
+++ b/phosphorus.js
@@ -399,6 +399,23 @@ var P = (function() {
     return cr;
   };
 
+  IO.loadSB2fromTosh = function(zip, callback, self) {
+    var cr = new CompositeRequest;
+    cr.defer = true;
+    var request = new Request;
+    cr.add(request);
+    cr.add(IO.loadSB2Object(zip, function(result) {
+      cr.defer = false;
+      cr.getResult = function() {
+        return result;
+      };
+      cr.update();
+    }));
+    request.load();
+    if (callback) cr.onLoad(callback.bind(self));
+    return cr;
+  };
+
   IO.loadProject = function(data) {
     IO.loadWavs();
     IO.loadArray(data.children, IO.loadObject);

--- a/phosphorus.js
+++ b/phosphorus.js
@@ -329,12 +329,12 @@ var P = (function() {
     return request;
   };
 
-  IO.loadSB2Project = function(ab, callback, self) {
+  IO.loadSB2Object = function(zip, callback, self) {
     var request = new CompositeRequest;
     IO.init(request);
 
     try {
-      IO.zip = new JSZip(ab);
+      IO.zip = zip;
       var json = IO.parseJSONish(IO.zip.file('project.json').asText());
 
       IO.loadProject(json);
@@ -352,6 +352,26 @@ var P = (function() {
     }
 
     return request;
+  };
+
+  IO.loadSB2Project = function(ab, callback, self) {
+    var cr = new CompositeRequest;
+    try {
+      var zip = new JSZip(ab);
+
+      cr.defer = true;
+      cr.add(IO.loadSB2Object(zip, function(result) {
+        cr.defer = false;
+        cr.getResult = function() {
+          return result;
+        };
+        cr.update();
+      }));
+    } catch (e) {
+      cr.error(e);
+    }
+    if (callback) cr.onLoad(callback.bind(self));
+    return cr;
   };
 
   IO.loadSB2File = function(f, callback, self) {


### PR DESCRIPTION
Took me ages to work out how `Request`/`CompositeRequest` work, but I think this is roughly what I want!

This way, I can construct a `zip` object like so:

``` javascript
    var zip = new JSZip();
    zip.file('project.json', JSON.stringify(p));
    zip.file('0.png', costume1.textFile);
    // ...
```

and then hand it straight to Phosphorus, avoiding the unnecessary `zip.generate()` step:

``` javascript
  var request = P.IO.loadSB2Object(zip);
  player.loadProject(request, function(stage) {
    // ...
```

Feedback on the name `loadSB2Object` is welcome.
