### PR TITLE
Don't allow sprites to goto NaN/Don't check for touching color when at non-finite position

### DIFF
--- a/phosphorus.js
+++ b/phosphorus.js
@@ -1684,6 +1684,7 @@ var P = (function() {
   };
 
   Sprite.prototype.touchingColor = function(rgb) {
+    if (!isFinite(this.scratchX) || !isFinite(this.scratchY)) return false;
     var b = this.rotatedBounds();
     collisionCanvas.width = b.right - b.left;
     collisionCanvas.height = b.top - b.bottom;

--- a/phosphorus.js
+++ b/phosphorus.js
@@ -1536,6 +1536,8 @@ var P = (function() {
   };
 
   Sprite.prototype.moveTo = function(x, y) {
+    if (x !== x) x = 0;
+    if (y !== y) y = 0;
     var ox = this.scratchX;
     var oy = this.scratchY;
     if (ox === x && oy === y && !this.isPenDown) return;


### PR DESCRIPTION
Fix #777 